### PR TITLE
added IF NOT EXISTS option on CREATE DATABASE statements

### DIFF
--- a/Driver/Mysql.php
+++ b/Driver/Mysql.php
@@ -54,7 +54,7 @@ class Mysql implements ProvidesDatabase
         $result = $this->queryManager->setConnection($this->system($tenant))
             ->process(function () use ($config) {
                 $this->statement("CREATE USER IF NOT EXISTS `{$config['username']}`@'{$config['host']}' IDENTIFIED BY '{$config['password']}'");
-                $this->statement("CREATE DATABASE `{$config['database']}`");
+                $this->statement("CREATE DATABASE IF NOT EXISTS `{$config['database']}`");
                 $this->statement("GRANT ALL ON `{$config['database']}`.* TO `{$config['username']}`@'{$config['host']}'");
             })
             ->getStatus();
@@ -80,7 +80,7 @@ class Mysql implements ProvidesDatabase
             ->process(function () use ($config, $tables) {
                 $this->statement("RENAME USER `{$config['oldUsername']}`@'{$config['host']}' TO `{$config['username']}`@'{$config['host']}'");
                 $this->statement("ALTER USER `{$config['username']}`@`{$config['host']}` IDENTIFIED BY '{$config['password']}'");
-                $this->statement("CREATE DATABASE `{$config['database']}`");
+                $this->statement("CREATE DATABASE IF NOT EXISTS `{$config['database']}`");
                 $this->statement("GRANT ALL ON `{$config['database']}`.* TO `{$config['username']}`@'{$config['host']}'");
 
                 foreach ($tables as $table) {


### PR DESCRIPTION
Hello,

While working with this MySQL driver I encountered some errors when database were already existing for the tenants. 

`SQLSTATE[HY000]: General error: 1007 Can't create database '*****'; database exists (SQL: CREATE DATABASE `*****`)`

I was working on a "resume tenant creation" feature on a project I'm working on so database was indeed already created and I see other way that the database might already be existing. 

After looking at the source code, I noticed that you already used _IF NOT EXISTS_ options for creating users or dropping database so I think it makes sense to also implement this option for database.

These changes are fixing the problem if it can be of some help.